### PR TITLE
Fix for collab inconsistent issue..

### DIFF
--- a/demo/server/DemoCollabController.js
+++ b/demo/server/DemoCollabController.js
@@ -88,17 +88,13 @@ function addEvents(
     checkVersion(docModel, version);
 
     if (docModel.version !== version) {
-      // [FS][18-MAY-2020][IRAD-901]
-      // skip throwing errors if found a version mismatch and
-      // used the server side version to rebase doc steps.
-      version = docModel.version;
-      /*const error: Object = new Error(
+      const error: Object = new Error(
         'Version not current. docModel.version = ' + docModel.version + ', ' +
         'params.version = ' + version
       );
       error.status = 409;
       reject(error);
-      return;*/
+      return;
     }
 
     // PM Process Start
@@ -152,10 +148,16 @@ function getEvents(docModel: DemoDocModel, version: number): ?Object {
 
 function checkVersion(docModel: DemoDocModel, version: number): void {
   if (version < 0 || version > docModel.version) {
-    // [FS][18-MAY-2020][IRAD-901]
-    // skip throwing errors if found a version mismatch and
-    // used the server side version to rebase doc steps.
-    version = docModel.version;
+    const err: Object = new Error(
+      'Invalid version. docModel.version = ' + docModel.version + ', ' +
+      'version = ' + version
+    );
+    // [FS] IRAD-901 2020-05-28
+    // Set conflict (409) instead of Bad request (400) so that
+    // re polling for changes and then try again, 
+    // if the client's document conflicts with the server's version at the client side.
+    err.status = 409;
+    throw err;
   }
 }
 


### PR DESCRIPTION
Set conflict (409) instead of Bad request (400) so that, re polling for changes and then try again,
if the client's document conflicts with the server's version at the
client side, when version mismatch occurs at server side.