### PR TITLE
Licit property onready

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 
 
 
+
+
 <h1 align="center">Licit Editor</h1>
 
 <div align="center">
@@ -121,6 +123,7 @@ ReactDOM.render(React.createElement(Licit, {docID:2}), document.getElementById("
 
  ```  
  By default, the *collaboration* and the *prosemirror dev tool* are disabled for the editor.
+ set  *docID* to *"0"* for disable the collaboration.
  User can enable the same using the below configuration:
  ```
  ReactDOM.render(React.createElement(Licit, {docID: 1, debug: true}), document.getElementById('root'));
@@ -130,7 +133,7 @@ Please refer *licit\client\index.js* for getting more detailed idea on passing p
 
 |Property Name| Description|Default Value| 
 |--|--|--|
-|docID  |Id of the collaborative document. Based on the value of _docID_ decides the collaboration communication |0
+|docID  |Id of the collaborative document. *docID "0"* means collaboration disabled. Based on the value of *docID* decides the collaboration communication |0
 | debug|Show/hide prosemirror dev tools|false
 | width|Width of the editor|100%
 | height|Height of the editor|100%
@@ -164,7 +167,6 @@ For example (in an Angular app):
  
 ```
 # At the working directory `licit`
-
 npm run build:licit
 ```  
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 
 
+
 <h1 align="center">Licit Editor</h1>
 
 <div align="center">
@@ -122,19 +123,27 @@ ReactDOM.render(React.createElement(Licit, {docID:2}), document.getElementById("
  By default, the *collaboration* and the *prosemirror dev tool* are disabled for the editor.
  User can enable the same using the below configuration:
  ```
- ReactDOM.render(React.createElement(Licit, {collaborative: true, docID: 1, debug: true}), document.getElementById('root'));
+ ReactDOM.render(React.createElement(Licit, {docID: 1, debug: true}), document.getElementById('root'));
 ```
+
+Please refer *licit\client\index.js* for getting more detailed idea on passing properties and fires events.
+
 |Property Name| Description|Default Value| 
 |--|--|--|
-|collaborative  | Enable/disable the collaborative functionality of this editor. |false
-|docID  |Id of the collaborative document. Used only when the collaboration is enabled. |1
+|docID  |Id of the collaborative document. Based on the value of _docID_ decides the collaboration communication |0
 | debug|Show/hide prosemirror dev tools|false
 | width|Width of the editor|100%
 | height|Height of the editor|100%
 | readOnly |To enable/disable editing mode|false
-| onChange |Fires after each significant change|null
 | data |Document data to be loaded into the editor|null
+| disabled|To disable the editor|false
 
+
+|Event Name| Description|Parameter| 
+|--|--|--|
+|onChange | Fires after each significant change |data
+|onReady| Fires once when the editor is ready |licit reference
+ 
 
 To load the styles:
 Either in *angular.json*, add

--- a/licit/client/index.js
+++ b/licit/client/index.js
@@ -16,7 +16,7 @@ function main(): void {
   // docJSON = null;
   // [FS] IRAD-982 2020-06-10
   // Use the licit component for demo.
-  ReactDOM.render(<Licit docID={1} collaborative={false} debug={false} width={'100vw'} height={'100vh'} onChange={onChangeCB} onReady={onReadyCB} data={docJSON}/>, el);
+  ReactDOM.render(<Licit docID={1} debug={false} width={'100vw'} height={'100vh'} onChange={onChangeCB} onReady={onReadyCB} data={docJSON}/>, el);
 }
 
 function onChangeCB(data) {

--- a/licit/client/index.js
+++ b/licit/client/index.js
@@ -16,11 +16,15 @@ function main(): void {
   // docJSON = null;
   // [FS] IRAD-982 2020-06-10
   // Use the licit component for demo.
-  ReactDOM.render(<Licit docID={1} collaborative={false} debug={false} width={'100vw'} height={'100vh'} onChange={onChangeCB} data={docJSON}/>, el);
+  ReactDOM.render(<Licit docID={1} collaborative={false} debug={false} width={'100vw'} height={'100vh'} onChange={onChangeCB} onReady={onReadyCB} data={docJSON}/>, el);
 }
 
 function onChangeCB(data) {
   console.log('data: ' + JSON.stringify(data));
+}
+
+function onReadyCB(ref) {
+  console.log('ref: ' + ref);
 }
 
 window.onload = main;

--- a/src/client/Licit.js
+++ b/src/client/Licit.js
@@ -178,7 +178,7 @@ class Licit extends React.Component<any, any, any> {
     editorView.focus();
 
     if (this.state.onReadyCB) {
-      this.state.onReadyCB(this.ref);
+      this.state.onReadyCB(this);
     }
 
     if (state.debug) {


### PR DESCRIPTION
1. FIX: Sometimes updating properties shows error in console - "unstable_flushDiscreteUpdates: Cannot flush updates when React is already rendering."
2. It should be possible to load content into the editor even when the editor is in read only mode. It should not be necessary to make the component writable any time during the process.
3. New property OnReady.
4. FIX: Once it's read-only it stays read-only.
5. Modified README.md file with new properties and events.